### PR TITLE
Fixes an issue with code 39 (and likely other representations) where the

### DIFF
--- a/grails-app/services/grails/plugin/barcode4j/Barcode4jService.groovy
+++ b/grails-app/services/grails/plugin/barcode4j/Barcode4jService.groovy
@@ -26,7 +26,7 @@ class Barcode4jService {
 	
 	def grailsApplication
 	
-	int defaultDpi = 150
+	int defaultDpi = 300
 	int defaultImageType = BufferedImage.TYPE_BYTE_BINARY
 	boolean defaultAntiAlias = false
 	int defaultOrientation = 0


### PR DESCRIPTION
resulting bar code is invalid when the DPI is set too low.  Changes the default
DPI to 300 from 150.

While many characters aren't rendered correctly it is easy to spot that the end
character is incorrect as it should end with a thin black bar but instead is
rendered as a thick black bar.

The valid image is generated with the DPI set to 300 while the invalid one is set to the old default of 150.

![12345_valid](https://f.cloud.github.com/assets/2708121/311295/299d2478-973a-11e2-903e-0ba44625836a.png)
![12345_invalid](https://f.cloud.github.com/assets/2708121/311296/299f5db0-973a-11e2-86ce-721df154b72c.png)
